### PR TITLE
Update the `radon` dependency from 1.4.0 to 1.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-radon==1.4.0
+radon==1.4.2
 requests==2.10.0
 PyYAML==3.11


### PR DESCRIPTION
**This dependency is out of date and is breaking something on my side which is not directly linked to xenon.** Whole story below.

My CI pipeline recently broke with the following exception:

```
+flake8 --ignore E501,F403,F401,F405 src
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.2/bin/flake8", line 11, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/main/cli.py", line 16, in main
    app.run(argv)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/main/application.py", line 316, in run
    self._run(argv)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/main/application.py", line 299, in _run
    self.initialize(argv)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/main/application.py", line 290, in initialize
    self.register_plugin_options()
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/main/application.py", line 150, in register_plugin_options
    self.check_plugins.register_options(self.option_manager)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/plugins/manager.py", line 457, in register_options
    list(self.manager.map(register_and_enable))
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/plugins/manager.py", line 267, in map
    yield func(self.plugins[name], *args, **kwargs)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/plugins/manager.py", line 453, in register_and_enable
    call_register_options(plugin)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/plugins/manager.py", line 363, in generated_function
    return method(optmanager, *args, **kwargs)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/flake8/plugins/manager.py", line 213, in register_options
    add_options(optmanager)
  File "/home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/radon/complexity.py", line 132, in add_options
    parser.config_options.append('radon-max-cc')
AttributeError: 'OptionManager' object has no attribute 'config_options'
```

This issue is unrelated to xenon but as I install xenon along with flake8, the installed version of `radon` is currently the 1.4.0. To work properly, flake8 needs the 1.4.2 version.

I understand this issue is completely out of scope of this project but I would like to spot the fact that **the installed dependency is out of date** and that this update would cause no harm to xenon while enabling it to be used more smoothly along with other widely-deployed tools such as flake8.