### PR TITLE
Force atleast requests 2.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 radon>=1.4.0,<1.5.0
-requests==2.10.0
+requests>=2.10.0
 PyYAML>=3.11,<=3.12


### PR DESCRIPTION
Not sure if there is a specific reason for having requests pinned to 2.10.0, but if theres not a strict requirement that perhaps merge this PR. Requests is at 2.18.1 as of today. If there is a strict reason than no worries! Either way thanks for the awesome package!