### PR TITLE
Fix check and move logger acquisition

### DIFF
--- a/xenon/__init__.py
+++ b/xenon/__init__.py
@@ -75,7 +75,7 @@ def main(args=None):
     args = args or parse_args()
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('xenon')
-    if len(args.path) > 1:
+    if args.url and len(args.path) > 1:
         logger.error(
             '-u, --url cannot be used when multiple paths are specified',
         )

--- a/xenon/__init__.py
+++ b/xenon/__init__.py
@@ -74,12 +74,12 @@ def main(args=None):
 
     args = args or parse_args()
     logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger('xenon')
     if len(args.path) > 1:
         logger.error(
             '-u, --url cannot be used when multiple paths are specified',
         )
         sys.exit(1)
-    logger = logging.getLogger('xenon')
     errors, cc_data = analyze(args, logger)
     exit_code = 0
     if args.url:


### PR DESCRIPTION
I am not sure, if it is the intended logic, but is stops xenon from failing, when passing multiple paths.