### PR TITLE
allow xenon to be run as a module (-m)

### DIFF
--- a/xenon/__main__.py
+++ b/xenon/__main__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""The main entry point. Invoke as `xenon' or `python -m xenon'.
+"""
+from . import main
+
+
+def entrypoint():
+    main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Many libraries such as `radon` allow for modules to be executed via [python -m](https://docs.python.org/3/using/cmdline.html#cmdoption-m).

This change allows for `python -m xenon` to work. This allows for CI or local machines that have multiple versions of python to execute xenon and know exactly which interpreter is being invoked.