### PR TITLE
Xenon takes new --max-average-num argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ nosetests.xml
 # Translations
 *.mo
 
+# Editors
+.idea
+
 # Mr Developer
 .mr.developer.cfg
 .project

--- a/test_xenon.py
+++ b/test_xenon.py
@@ -10,7 +10,7 @@ from paramunittest import parametrized
 from xenon import core, api, main
 
 
-Args = collections.namedtuple('Args', 'absolute average modules')
+Args = collections.namedtuple('Args', 'absolute average modules averagenum')
 
 
 class CatchAll(object):
@@ -32,6 +32,7 @@ class Arguments(object):
     average = None
     absolute = None
     modules = None
+    averagenum = None
 
 
 @parametrized(
@@ -71,46 +72,46 @@ class CheckTestCase(unittest.TestCase):
 
 @parametrized(
     # results
-    # absolute, average, modules
+    # absolute, average, modules, averagenum
     # exit code
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        ('C', 'B', 'B'),
+        ('C', 'B', 'B', None),
         0
     ),
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        ('B', 'B', 'B'),
+        ('B', 'B', 'B', None),
         1
     ),
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        ('C', 'A', 'B'),
+        ('C', 'A', 'B', None),
         1
     ),
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        ('C', 'B', 'A'),
+        ('C', 'B', 'A', None),
         1
     ),
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        (None, 'B', 'B'),
+        (None, 'B', 'B', None),
         0
     ),
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        ('C', None, 'B'),
+        ('C', None, 'B', None),
         0
     ),
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        ('C', 'B', None),
+        ('C', 'B', None, None),
         0
     ),
     (
         {'mod.py': [4, 12, 8, 9], 'mod2.py': [3, 3, 2, 10]},
-        (None, None, None),
+        (None, None, None, 0),
         0
     ),
 )

--- a/xenon/__init__.py
+++ b/xenon/__init__.py
@@ -22,7 +22,9 @@ def parse_args():
     parser.add_argument('path', help='Directory containing source files to '
                         'analyze, or multiple file paths', nargs='+')
     parser.add_argument('-a', '--max-average', dest='average', metavar='<str>',
-                        help='Threshold for the average complexity')
+                        help='Letter grade threshold for the average complexity')
+    parser.add_argument('--max-average-num', dest='averagenum', type=float,
+                        help='Numeric threshold for the average complexity')
     parser.add_argument('-m', '--max-modules', dest='modules', metavar='<str>',
                         help='Threshold for modules complexity')
     parser.add_argument('-b', '--max-absolute', dest='absolute',

--- a/xenon/core.py
+++ b/xenon/core.py
@@ -72,7 +72,13 @@ def find_infractions(args, logger, results):
         total_cc += module_cc
         total_blocks += len(blocks)
 
-    ar = cc_rank(av(total_cc, total_blocks))
+    av_cc = av(total_cc, total_blocks)
+    ar = cc_rank(av_cc)
+
+    if args.averagenum is not None and av_cc > args.averagenum:
+        logger.error('total average complexity is %s', av_cc)
+        infractions += 1
+
     if check(ar, args.average):
         logger.error('average complexity is ranked %s', ar)
         infractions += 1


### PR DESCRIPTION
I wanted to be able to run this
`xenon code --max-average A --max-modules C --max-absolute D --max-average-num 2.3`

While this new argument is similar to max-average, it let's you threshold to a more specific value while you're still improving the code's complexity.

