### PR TITLE
Fixed radon dependency (https://github.com/rubik/xenon/issues/38)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-radon>=4,<5
+radon[flake8]>=4,<5
 requests>=2.0,<3.0
 PyYAML>=4.2b1,<6.0


### PR DESCRIPTION
With this change in radon (https://github.com/rubik/radon/commit/2c9627de5fccf7bb878283c340c61c0cd5042db8), flake8_polyfill became an optional dependency.