### PR TITLE
widen required radon version to include 5.x

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-radon = "<3,>=2"
+radon = "<6,>=4"
 requests = "<3.0,>=2.0"
 PyYAML = ">=4.2b1,<5.0"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-radon>=4,<5
+radon>=4,<6
 requests>=2.0,<3.0
 PyYAML>=4.2b1,<6.0


### PR DESCRIPTION
This is a fix for #42