### PR TITLE
Add the option to ignore by block name, instead of by module

### DIFF
--- a/xenon/__init__.py
+++ b/xenon/__init__.py
@@ -36,6 +36,9 @@ def parse_args():
                         help='Comma separated list of patterns to ignore. If '
                         'they are directories, Xenon won\'t even descend into '
                         'them')
+    parser.add_argument('-ib', '--ignore-blocks', metavar='<str>', dest='ignore_blocks',
+                        help='Comma separated list of blocks to ignore.' 
+                             'Block format is "module:block_name"')
     parser.add_argument('-u', '--url', metavar='<URL>', dest='url',
                         help='Where to send the JSON data through a POST '
                         'request.')


### PR DESCRIPTION
I want to use xenon to prevent developers in my organization from adding new bad blocks, but still don't fail for existing bad blocks. Ignore/Exclude only allows to exclude by module, this isn't specific enough for us. 