### PR TITLE
Add 'link' option to skip loglevel and module info in output

### DIFF
--- a/xenon/__init__.py
+++ b/xenon/__init__.py
@@ -45,6 +45,8 @@ def parse_args():
     parser.add_argument('-c', '--config-file', metavar='<path>', dest='config',
                         default='.xenon.yml', help='Xenon config file '
                         '(default: %(default)s)')
+    parser.add_argument('-l', '--links', dest='links', action='store_true',
+                        help='Print output starting with the file path')
 
     args = parser.parse_args()
     # normalize the rank
@@ -75,7 +77,13 @@ def main(args=None):
     from xenon.repository import gitrepo
 
     args = args or parse_args()
-    logging.basicConfig(level=logging.INFO)
+    if args.links:
+        # Skip the level and module name to have log line starting with message
+        # When using xenon in PyCharm terminal, one can benefit from
+        # PyCharm changing path to the violation location into the active link
+        logging.basicConfig(level=logging.INFO, format='%(message)s')
+    else:
+        logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger('xenon')
     if args.url and len(args.path) > 1:
         logger.error(

--- a/xenon/core.py
+++ b/xenon/core.py
@@ -65,8 +65,12 @@ def find_infractions(args, logger, results):
             module_cc += block['complexity']
             r = cc_rank(block['complexity'])
             if check(r, args.absolute):
-                logger.error('block "%s:%s %s" has a rank of %s', module,
-                             block['lineno'], block['name'], r)
+                if args.links:
+                    logger.error('%s:%s "%s" block has a rank of %s', module,
+                            block['lineno'], block['name'], r)
+                else:
+                    logger.error('block "%s:%s %s" has a rank of %s', module,
+                            block['lineno'], block['name'], r)
                 infractions += 1
         module_averages.append((module, av(module_cc, len(blocks))))
         total_cc += module_cc
@@ -85,6 +89,9 @@ def find_infractions(args, logger, results):
     for module, ma in module_averages:
         mar = cc_rank(ma)
         if check(mar, args.modules):
-            logger.error('module %r has a rank of %s', module, mar)
+            if args.links:
+                logger.error('%r module has a rank of %s', module, mar)
+            else:
+                logger.error('module %r has a rank of %s', module, mar)
             infractions += 1
     return infractions


### PR DESCRIPTION
Skip the level and module name to have log line starting with message.
This option affects also how the "block" and "module" violations are printed - the path is in the front of the message.
When using xenon in PyCharm terminal, one can benefit from PyCharm changing the path to the violation location into the active link.

For more details see Feature Request #49 